### PR TITLE
Add duplex stream support

### DIFF
--- a/fromDuplex.ts
+++ b/fromDuplex.ts
@@ -1,0 +1,21 @@
+import type { Duplex } from "stream";
+import { fromReadable } from "./fromReadable";
+import { fromWritable } from "./fromWritable";
+
+/**
+ * Converts a Node.js Duplex stream to a Web API TransformStream
+ * @template IN - The type of data being written (string or Uint8Array)
+ * @template OUT - The type of data being read (string or Uint8Array)
+ * @param duplex - The Node.js duplex stream to convert
+ * @returns A Web API TransformStream that wraps the Node.js duplex stream
+ */
+export function fromDuplex<IN extends string | Uint8Array, OUT extends string | Uint8Array>(
+  duplex: Duplex | TransformStream
+): TransformStream<IN, OUT> {
+  if (duplex instanceof TransformStream) return duplex;
+  
+  return {
+    readable: fromReadable<OUT>(duplex),
+    writable: fromWritable<IN>(duplex),
+  };
+}

--- a/index.spec.ts
+++ b/index.spec.ts
@@ -1,6 +1,8 @@
 import { exec } from "child_process";
+import { Transform } from "stream";
 import sflow from "sflow";
 import { fromStdioDropErr, fromStdioMergeError } from ".";
+import { fromDuplex } from "./fromDuplex";
 import { fromReadable } from "./fromReadable";
 import { fromWritable } from "./fromWritable";
 
@@ -38,4 +40,29 @@ it("fromStdio merge error", async () => {
     .by(fromStdioMergeError(p))
     .text();
   expect(output).toBe("oops, error\nhell, word\n");
+});
+
+it("fromDuplex works with Transform stream", async () => {
+  const transform = new Transform({
+    transform(chunk, encoding, callback) {
+      this.push(chunk.toString().toUpperCase());
+      callback();
+    }
+  });
+
+  const output = await sflow("hello world\n")
+    .by(fromDuplex(transform))
+    .text();
+  expect(output).toBe("HELLO WORLD\n");
+});
+
+it("fromDuplex works with existing TransformStream", async () => {
+  const upperCaseTransform = new TransformStream({
+    transform(chunk, controller) {
+      controller.enqueue(chunk.toString().toUpperCase());
+    }
+  });
+
+  const result = fromDuplex(upperCaseTransform);
+  expect(result).toBe(upperCaseTransform);
 });

--- a/index.ts
+++ b/index.ts
@@ -2,6 +2,7 @@ import { mergeStream } from "sflow"; // TODO: ensure tree shake sflow
 import { Readable, Writable } from "stream";
 import { fromReadable } from "./fromReadable";
 import { fromWritable } from "./fromWritable";
+import { fromDuplex } from "./fromDuplex";
 
 /**
  * Creates a TransformStream from a process's stdio, dropping stderr output
@@ -114,4 +115,4 @@ export function fromStdio<IN extends string | Uint8Array, OUT extends string | U
 
 }
 
-export { fromReadable, fromWritable };
+export { fromReadable, fromWritable, fromDuplex };

--- a/package.json
+++ b/package.json
@@ -7,9 +7,10 @@
     "node-stream",
     "Readable",
     "Writable",
+    "Duplex",
     "ReadableStream",
     "WritableStream",
-    "TransformSteam"
+    "TransformStream"
   ],
   "homepage": "https://github.com/snomiao/from-node-stream#readme",
   "bugs": {


### PR DESCRIPTION
## Summary
- Add `fromDuplex` function to convert Node.js Duplex streams to Web API TransformStreams
- Export `fromDuplex` from main index for easy access
- Add comprehensive tests covering both Node.js Transform streams and existing TransformStreams
- Update package keywords to include "Duplex" and fix "TransformSteam" typo to "TransformStream"

## Test plan
- [x] Added tests for `fromDuplex` with Node.js Transform streams
- [x] Added tests for `fromDuplex` with existing Web API TransformStreams  
- [x] All existing tests continue to pass
- [x] TypeScript compilation succeeds
- [x] Build process completes successfully

🤖 Generated with [Claude Code](https://claude.ai/code)